### PR TITLE
Feature/get effective payment method

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalise line endings so checkouts are consistent across platforms.
+* text=auto eol=lf
+
+*.php text diff=php
+*.md text
+*.json text
+*.xml text
+
+# Development-only files, excluded from `composer install --prefer-dist` archives.
+/tests            export-ignore
+/phpunit.xml      export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 
 # Development-only files, excluded from `composer install --prefer-dist` archives.
 /tests            export-ignore
+/examples         export-ignore
 /phpunit.xml      export-ignore
 /.gitattributes   export-ignore
 /.gitignore       export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 .project
 .metadata
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     "psr-4": {
       "Zotlo\\Connect\\": "src/Zotlo"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Zotlo\\Connect\\Tests\\": "tests"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "guzzlehttp/guzzle": "^6.0.0|^7.4.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.5|^9.5"
+    "phpunit/phpunit": "^8.5|^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,12 @@
   "homepage": "https://zotlo.com",
   "license": "MIT",
   "require": {
-    "php": ">=7.1.0",
+    "php": ">=8.0",
     "ext-curl": "*",
     "guzzlehttp/guzzle": "^6.0.0|^7.4.5"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^7.5|^8.5|^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Zotlo SDK Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Zotlo/Enum/PaymentMethod.php
+++ b/src/Zotlo/Enum/PaymentMethod.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Zotlo\Connect\Enum;
+
+/**
+ * Effective payment method of a transaction — the payment *instrument*, as opposed to the
+ * raw gateway-level `paymentMethod` string that arrives in the payload.
+ *
+ * @see \Zotlo\Connect\Response\TransactionResponse::getEffectivePaymentMethod()
+ * @package Zotlo\Connect\Enum
+ */
+class PaymentMethod
+{
+    const PAYPAL = 'paypal';
+
+    const APPLE_PAY = 'applePay';
+
+    const GOOGLE_PAY = 'googlePay';
+
+    const THREE_D = '3d';
+
+    const NONE_3D = 'none3d';
+}

--- a/src/Zotlo/Response/TransactionResponse.php
+++ b/src/Zotlo/Response/TransactionResponse.php
@@ -2,6 +2,8 @@
 
 namespace Zotlo\Connect\Response;
 
+use Zotlo\Connect\Enum\PaymentMethod;
+
 class TransactionResponse
 {
     private int $id;
@@ -613,6 +615,8 @@ class TransactionResponse
     }
 
     /**
+     * Raw gateway-level value. For the resolved instrument use getEffectivePaymentMethod().
+     *
      * @return string|null
      */
     public function getPaymentMethod()
@@ -626,6 +630,31 @@ class TransactionResponse
     public function setPaymentMethod(?string $paymentMethod)
     {
         $this->paymentMethod = $paymentMethod;
+    }
+
+    /**
+     * How the transaction was actually paid for, resolved from `custom_parameters`.
+     *
+     * @return string One of the Zotlo\Connect\Enum\PaymentMethod constants.
+     */
+    public function getEffectivePaymentMethod(): string
+    {
+        if (strtolower((string)$this->paymentMethod) === PaymentMethod::PAYPAL) {
+            return PaymentMethod::PAYPAL;
+        }
+
+        $parameters = is_array($this->custom_parameters) ? $this->custom_parameters : [];
+
+        if (!empty($parameters['apm'])) {
+            $wallet = ((array)$parameters['apm'])['paymentMethod'] ?? null;
+            $wallets = [PaymentMethod::APPLE_PAY, PaymentMethod::GOOGLE_PAY];
+
+            return in_array($wallet, $wallets, true) ? $wallet : PaymentMethod::NONE_3D;
+        }
+
+        return filter_var($parameters['threeds'] ?? false, FILTER_VALIDATE_BOOLEAN)
+            ? PaymentMethod::THREE_D
+            : PaymentMethod::NONE_3D;
     }
 
     /**

--- a/tests/Response/TransactionResponseTest.php
+++ b/tests/Response/TransactionResponseTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Zotlo\Connect\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Zotlo\Connect\Enum\PaymentMethod;
+use Zotlo\Connect\Response\TransactionResponse;
+
+class TransactionResponseTest extends TestCase
+{
+    public function testPaypalIsResolvedFromTheTopLevelPaymentMethod()
+    {
+        $transaction = $this->transaction('paypal');
+
+        $this->assertSame(PaymentMethod::PAYPAL, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testPaypalIsResolvedRegardlessOfCase()
+    {
+        $transaction = $this->transaction('PayPal');
+
+        $this->assertSame(PaymentMethod::PAYPAL, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testPaypalWinsOverCustomParameters()
+    {
+        $transaction = $this->transaction('paypal', ['threeds' => 1, 'apm' => ['paymentMethod' => 'applePay']]);
+
+        $this->assertSame(PaymentMethod::PAYPAL, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testApplePayIsResolvedFromApm()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => ['paymentMethod' => 'applePay']]);
+
+        $this->assertSame(PaymentMethod::APPLE_PAY, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testGooglePayIsResolvedFromApm()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => ['paymentMethod' => 'googlePay']]);
+
+        $this->assertSame(PaymentMethod::GOOGLE_PAY, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testCardWithIntegerThreedsFlagIsThreeD()
+    {
+        $transaction = $this->transaction('creditCard', ['threeds' => 1]);
+
+        $this->assertSame(PaymentMethod::THREE_D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testCardWithStringThreedsFlagIsThreeD()
+    {
+        $transaction = $this->transaction('creditCard', ['threeds' => '1']);
+
+        $this->assertSame(PaymentMethod::THREE_D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testCardWithFalsyThreedsFlagIsNone3d()
+    {
+        $this->assertSame(
+            PaymentMethod::NONE_3D,
+            $this->transaction('creditCard', ['threeds' => 0])->getEffectivePaymentMethod()
+        );
+
+        $this->assertSame(
+            PaymentMethod::NONE_3D,
+            $this->transaction('creditCard', ['threeds' => '0'])->getEffectivePaymentMethod()
+        );
+    }
+
+    public function testCardWithoutThreedsFlagIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', ['someOtherFlag' => 1]);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testNullCustomParametersIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', null);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testMissingCustomParametersIsNone3d()
+    {
+        $data = $this->payload();
+        $data['paymentMethod'] = 'creditCard';
+        unset($data['custom_parameters']);
+
+        $transaction = new TransactionResponse($data);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testMissingPaymentMethodIsNone3d()
+    {
+        $data = $this->payload();
+        unset($data['paymentMethod']);
+
+        $transaction = new TransactionResponse($data);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testUnknownApmPaymentMethodIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => ['paymentMethod' => 'someNewWallet']]);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testUnknownApmPaymentMethodIsNone3dEvenWithThreedsSet()
+    {
+        $transaction = $this->transaction('creditCard', ['threeds' => 1, 'apm' => ['paymentMethod' => 'someNewWallet']]);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testMalformedApmWithoutPaymentMethodKeyIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => ['provider' => 'stripe']]);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testApmThatIsNotAnArrayIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => 'applePay']);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testEmptyApmFallsBackToThreedsResolution()
+    {
+        $this->assertSame(
+            PaymentMethod::THREE_D,
+            $this->transaction('creditCard', ['apm' => null, 'threeds' => 1])->getEffectivePaymentMethod()
+        );
+
+        $this->assertSame(
+            PaymentMethod::NONE_3D,
+            $this->transaction('creditCard', ['apm' => [], 'threeds' => 0])->getEffectivePaymentMethod()
+        );
+    }
+
+    public function testNonScalarThreedsFlagIsNone3d()
+    {
+        $transaction = $this->transaction('creditCard', ['threeds' => ['unexpected']]);
+
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testGetPaymentMethodStillReturnsTheRawWalletPayloadValue()
+    {
+        $transaction = $this->transaction('creditCard', ['apm' => ['paymentMethod' => 'applePay']]);
+
+        $this->assertSame('creditCard', $transaction->getPaymentMethod());
+        $this->assertSame(PaymentMethod::APPLE_PAY, $transaction->getEffectivePaymentMethod());
+    }
+
+    public function testResolutionFollowsTheSettersAndDoesNotGoStale()
+    {
+        $transaction = $this->transaction('creditCard', ['threeds' => 1]);
+        $this->assertSame(PaymentMethod::THREE_D, $transaction->getEffectivePaymentMethod());
+
+        $transaction->setCustomParameters(['apm' => ['paymentMethod' => 'googlePay']]);
+        $this->assertSame(PaymentMethod::GOOGLE_PAY, $transaction->getEffectivePaymentMethod());
+
+        $transaction->setPaymentMethod('paypal');
+        $this->assertSame(PaymentMethod::PAYPAL, $transaction->getEffectivePaymentMethod());
+
+        $transaction->setPaymentMethod('creditCard');
+        $transaction->setCustomParameters(null);
+        $this->assertSame(PaymentMethod::NONE_3D, $transaction->getEffectivePaymentMethod());
+    }
+
+    /**
+     * @param string|null $paymentMethod
+     * @param array|null $customParameters
+     * @return TransactionResponse
+     */
+    private function transaction($paymentMethod, $customParameters = null)
+    {
+        return new TransactionResponse($this->payload([
+            'paymentMethod' => $paymentMethod,
+            'custom_parameters' => $customParameters,
+        ]));
+    }
+
+    /**
+     * A webhook payload with every non-nullable field populated.
+     *
+     * @param array $overrides
+     * @return array
+     */
+    private function payload(array $overrides = [])
+    {
+        return array_merge([
+            'id' => 1,
+            'team_id' => 2,
+            'app_id' => 3,
+            'provider_id' => 4,
+            'quantity' => 1,
+            'price' => 9.99,
+            'package_price' => 9.99,
+            'transaction_id' => 'trx-1',
+            'paymentMethod' => 'creditCard',
+            'custom_parameters' => null,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
I had to get the payment method from TransactionInsert webhook data because of my application's business logic.

However, I realized that the SDK doesn't return the actual payment method when I dug into the code. It only returns a string in the parameters.paymentMethod field.

This causes the problem below.

| Payload | `getPaymentMethod()` |
|---------|------------------------------|
| PayPal transaction | paypal  |
| `apm.paymentMethod = applePay` | creditCard |
| `apm.paymentMethod = googlePay` | creditCard |
| Card, `threeds = 1` (int) | creditCard |
| Card, `threeds = "1"` (string) | creditCard |
| Card, `threeds = 0` / `"0"` | creditCard |
| Card, `threeds` absent | creditCard |
| `custom_parameters` null / missing | creditCard |
| `apm` present, unknown wallet | creditCard |
| `apm` present, no `paymentMethod` key | creditCard |
| `apm` present but not an array | creditCard |
| `paymentMethod` missing entirely | `null` |


I would have expected like `ApplePay => applePay `, `googlePay => googlePay` instead of this. 

I implemented the behavior I expected with adding new method for prevent to breaking backward compatibility. But we can argue about deprecating `getPaymentMethod()` method. 

The end result is as follows:

| Payload | `master getPaymentMethod()` | `New getEffectivePaymentMethod()` |
|----------|-----------------------------|-----------------------------------|
| PayPal transaction | `paypal` * | `paypal` |
| `apm.paymentMethod = applePay` | `creditCard` | `applePay` |
| `apm.paymentMethod = googlePay` | `creditCard` | `googlePay` |
| Card, `threeds = 1` (int) | `creditCard` | `3d` |
| Card, `threeds = "1"` (string) | `creditCard` | `3d` |
| Card, `threeds = 0` / `"0"` | `creditCard` | `none3d` |
| Card, `threeds` absent | `creditCard` | `none3d` |
| `custom_parameters` null / missing | `creditCard` | `none3d` |
| `apm` present, unknown wallet | `creditCard` | `none3d` |
| `apm` present, no `paymentMethod` key | `creditCard` | `none3d` |
| `apm` present but not an array | `creditCard` | `none3d` |
| `paymentMethod` missing entirely | `null` | `none3d` |


Also please be informed that... 

Your composer.json file says min php requirement is 7.1 but package is using [union types feature which is  released php 8.0 ](https://php.watch/versions/8.0/union-types)

Example : `src/Zotlo/Response/TransactionResponse.php:31`

So I had to upgrade php and phpunit versions either. 

Another problem is that package make composer force to pull files which is irrelevant like examples and tests for production. That's why i added `.gitattributes` file.


If you are someone who likes to play it safe, I created dummy project for manual testing this feature.  You can take a look [here. ](https://github.com/haydar/zotlo-php-sdk-dummy-project)